### PR TITLE
Relax faraday library version constraint

### DIFF
--- a/epsilla-ruby.gemspec
+++ b/epsilla-ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "faraday", "~> 1"
+  spec.add_dependency "faraday", ">= 1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
@@ -88,7 +88,7 @@ end
 #   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 #   spec.require_paths = ["lib"]
 
-#   spec.add_dependency "faraday", "~> 1"
+#   spec.add_dependency "faraday", ">= 1"
 #   spec.add_development_dependency "bundler", "~> 1.17"
 # end
 

--- a/epsilla.gemspec
+++ b/epsilla.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "faraday", "~> 1"
+  spec.add_dependency "faraday", ">= 1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/epsilla/version.rb
+++ b/lib/epsilla/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Epsilla
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
I am integrating Epsilla with [langchainrb](https://github.com/andreibondarev/langchainrb), a popular Ruby library. [WIP branch here](https://github.com/tonyyanga/langchainrb/pull/1). There is a gem conflict on `faraday`. Many libraries have bumped faraday version to v2, and will be reported as a conflict.

The specific conflict comes from:
- qdrant
- open-weather-ruby-client

Relaxing the gem version constraint fixes the issue.